### PR TITLE
Update Payola service to save the stripeToken

### DIFF
--- a/app/services/payola/create_subscription.rb
+++ b/app/services/payola/create_subscription.rb
@@ -7,7 +7,7 @@ module Payola
       sub = Payola::Subscription.new do |s|
         s.plan = plan
         s.email = params[:stripeEmail]
-        s.stripe_token = params[:stripeToken] if plan.amount > 0
+        s.stripe_token = params[:stripeToken]
         s.affiliate_id = affiliate.try(:id)
         s.currency = plan.respond_to?(:currency) ? plan.currency : Payola.default_currency
         s.coupon = params[:coupon]


### PR DESCRIPTION
Even when the amount of the transaction is 0,
We need the token to create subsequent charges.
